### PR TITLE
Refactor/1 memo로 컴포넌트 리렌더링 방지

### DIFF
--- a/src/components/Common/DiaryEditor/index.tsx
+++ b/src/components/Common/DiaryEditor/index.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useRef, useContext, useEffect } from "react";
+import React, {
+  useState,
+  useRef,
+  useContext,
+  useEffect,
+  useCallback,
+} from "react";
 import { useNavigate } from "react-router";
 import * as S from "./style";
 import { DiaryDispatchContext } from "../../../App";
@@ -23,9 +29,9 @@ const DiaryEditor = ({ isEdit, originData }: PropsType) => {
 
   const { onCreate, onEdit, onRemove } = useContext(DiaryDispatchContext);
 
-  const handleClickEmote = (emotionId: number) => {
+  const handleClickEmote = useCallback((emotionId: number) => {
     setEmotion(emotionId);
-  };
+  }, []);
 
   const handleSubmit = () => {
     if (content.length < 1) {

--- a/src/components/Common/EmotionItem.tsx/index.tsx
+++ b/src/components/Common/EmotionItem.tsx/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import * as S from "./style";
 
 type PropsType = {
@@ -22,4 +22,6 @@ const EmotionItem = ({ id, img, descript, onClick, isSelected }: PropsType) => (
   </S.EmotionItem>
 );
 
-export default EmotionItem;
+const MemoizedEmotionItem = memo<typeof EmotionItem>(EmotionItem);
+
+export default MemoizedEmotionItem;

--- a/src/components/Home/HomeController/index.tsx
+++ b/src/components/Home/HomeController/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import * as S from "./style";
 
 type PropsType = {
@@ -20,4 +20,6 @@ const HomeController = ({ value, onChange, optionList = [] }: PropsType) => (
   </S.Select>
 );
 
-export default HomeController;
+const MemoizedHomeController = memo<typeof HomeController>(HomeController);
+
+export default MemoizedHomeController;

--- a/src/components/Home/HomeDiaryItem.tsx/index.tsx
+++ b/src/components/Home/HomeDiaryItem.tsx/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { useNavigate } from "react-router";
 import * as S from "./style";
 import Button from "../../Common/Button";
@@ -46,4 +46,6 @@ const HomeDiaryItem = ({ id, emotion, content, date }: DiaryItemType) => {
   );
 };
 
-export default HomeDiaryItem;
+const MemoizedHomeDiaryItem = memo<typeof HomeDiaryItem>(HomeDiaryItem);
+
+export default MemoizedHomeDiaryItem;

--- a/src/components/Home/HomeDiaryList/index.tsx
+++ b/src/components/Home/HomeDiaryList/index.tsx
@@ -11,20 +11,20 @@ type PropsType = {
 };
 type CompareType = (a: DiaryItemType, b: DiaryItemType) => number;
 
+const sortOptionList = [
+  { value: "latest", name: "최신순" },
+  { value: "oldest", name: "지난순" },
+];
+const filterOptionList = [
+  { value: "all", name: "전부다" },
+  { value: "good", name: "좋은" },
+  { value: "bad", name: "안좋은" },
+];
+
 const DiaryList = ({ diaryList }: PropsType) => {
   const [sortType, setSortType] = useState("latest");
   const [filter, setFilter] = useState("all");
   const navigate = useNavigate();
-
-  const sortOptionList = [
-    { value: "latest", name: "최신순" },
-    { value: "oldest", name: "지난순" },
-  ];
-  const filterOptionList = [
-    { value: "all", name: "전부다" },
-    { value: "good", name: "좋은" },
-    { value: "bad", name: "안좋은" },
-  ];
 
   const getProcessdDiaryList = () => {
     const compareByDate: CompareType = (a, b) => {


### PR DESCRIPTION
emotionItem 컴포넌트, DiaryItem 컴포넌트,  HomeController 컴포넌트에 memo를 감싸주었음.

각자 이미지를 갖고 있거나 목록이 얼마나 늘어날 지 모르거나 텍스트의 길이가 얼마나 길어질 지 모르는 컴포넌트이기 때문에 memo를 사용함.