### PR TITLE
Refactor/9 lighthouse 진단을 활용하여 품질 최적화

### DIFF
--- a/src/components/Common/Button/style.tsx
+++ b/src/components/Common/Button/style.tsx
@@ -16,7 +16,7 @@ export const Button = styled.button<{ variant: string }>`
       return css`
         width: 100%;
         background-color: #64c964;
-        color: white;
+        color: black;
       `;
 
     if (variant === "negative")

--- a/src/components/Common/DiaryEditor/index.tsx
+++ b/src/components/Common/DiaryEditor/index.tsx
@@ -87,9 +87,14 @@ const DiaryEditor = ({ isEdit, originData }: PropsType) => {
         }
       />
       <S.DiaryEditorSection>
-        <S.DiaryEditorTitle2>오늘은 언제인가요?</S.DiaryEditorTitle2>
+        <S.DiaryEditorTitle2>
+          <S.DiaryEditorLabel htmlFor="date">
+            오늘은 언제인가요?
+          </S.DiaryEditorLabel>
+        </S.DiaryEditorTitle2>
         <S.DiaryEditorInputContainer>
           <S.DiaryEditorInput
+            id="date"
             value={date}
             type="date"
             onChange={(e) => setDate(e.target.value)}

--- a/src/components/Common/DiaryEditor/style.tsx
+++ b/src/components/Common/DiaryEditor/style.tsx
@@ -6,6 +6,8 @@ export const DiaryEditorSection = styled.section`
   }
 `;
 
+export const DiaryEditorLabel = styled.label``;
+
 export const DiaryEditorTitle2 = styled.h2`
   margin: 2rem 0;
   font-size: 2.2rem;

--- a/src/components/Common/EmotionItem/style.tsx
+++ b/src/components/Common/EmotionItem/style.tsx
@@ -12,7 +12,7 @@ export const EmotionItem = styled.li<{ isOn: boolean; variant: number }>`
   padding: 2rem 0;
   background-color: ${({ isOn, variant }) =>
     isOn ? palette[colors[variant - 1]] : "#ececec"};
-  color: ${({ isOn }) => (isOn ? "white" : "black")};
+  color: "black";
   cursor: pointer;
 `;
 

--- a/src/components/Home/HomeDiaryItem/index.tsx
+++ b/src/components/Home/HomeDiaryItem/index.tsx
@@ -33,7 +33,10 @@ const HomeDiaryItem = ({ id, emotion, content, date }: DiaryItemType) => {
   return (
     <S.DiaryItem>
       <S.ImageContainer color={colors[emotion - 1]} onClick={goToDetailPage}>
-        <S.EmotionTimage src={emotionList[emotion - 1]} />
+        <S.EmotionTimage
+          src={emotionList[emotion - 1]}
+          alt={`${colors[emotion - 1]} emotional state`}
+        />
       </S.ImageContainer>
       <S.InformationContainer onClick={goToDetailPage}>
         <S.DiaryDate>{stringDate}</S.DiaryDate>

--- a/src/components/Home/HomeDiaryItem/style.tsx
+++ b/src/components/Home/HomeDiaryItem/style.tsx
@@ -24,9 +24,7 @@ export const DiaryDate = styled.time`
   font-size: 2.5rem;
 `;
 
-export const EmotionTimage = styled.img`
-  width: 50%;
-`;
+export const EmotionTimage = styled.img``;
 
 export const ButtonContainer = styled.div`
   min-width: 7rem;

--- a/src/components/Home/HomeDiaryList/index.tsx
+++ b/src/components/Home/HomeDiaryList/index.tsx
@@ -46,7 +46,7 @@ const DiaryList = ({ diaryList }: PropsType) => {
   };
 
   return (
-    <div>
+    <S.Container>
       <S.ControllerContainer>
         <S.LeftContainer>
           <HomeController
@@ -73,7 +73,7 @@ const DiaryList = ({ diaryList }: PropsType) => {
           <HomeDiaryItem key={diary.id} {...diary} />
         ))}
       </S.DiaryList>
-    </div>
+    </S.Container>
   );
 };
 

--- a/src/components/Home/HomeDiaryList/style.tsx
+++ b/src/components/Home/HomeDiaryList/style.tsx
@@ -14,3 +14,5 @@ export const RightContainer = styled.div`
 `;
 
 export const DiaryList = styled.ul``;
+
+export const Container = styled.div``;

--- a/src/styles/GlobalFont.tsx
+++ b/src/styles/GlobalFont.tsx
@@ -8,12 +8,14 @@ const GlobalFont = createGlobalStyle`
      @font-face {
         font-family: "nanum";
         src: local("nanum"), url(${NanumPenRegular}) format('woff'); 
-        font-weight: normal;
+        font-weight: normal;        
+        font-display: swap;
     }
     @font-face {
         font-family: "yeonsung";
         src: local("yeonsung"), url(${YeonSungRegular}) format('woff');
         font-weight: normal;
+        font-display: swap;
     }
 `;
 

--- a/src/styles/GlobalFont.tsx
+++ b/src/styles/GlobalFont.tsx
@@ -9,13 +9,13 @@ const GlobalFont = createGlobalStyle`
         font-family: "nanum";
         src: local("nanum"), url(${NanumPenRegular}) format('woff'); 
         font-weight: normal;        
-        font-display: swap;
+        font-display: fallback;
     }
     @font-face {
         font-family: "yeonsung";
         src: local("yeonsung"), url(${YeonSungRegular}) format('woff');
         font-weight: normal;
-        font-display: swap;
+        font-display: fallback;
     }
 `;
 


### PR DESCRIPTION
1. 웹 폰트가 로드되는 동안 텍스트 계속 표기하기.

성능과 디자인, 즉 FOIT와 FOUT중 선택이 필요했다. 사이트의 규모가 크지 않기에 0.1초의 폰트가 로드될 때 까지 block하는 방식이 좋아보였지만 3G환경에서는 보이지 않는 블럭을 오랜 시간 멍하니 바라보게 되는 이슈가 생겼다.  `font-display : fallback` 지시자를 사용하여 구간 별로 대처를 취하고 3초이내에 로드가 안된다면 기본 폰트를 보여주게 만들었다.

하지만 아무래도 폰트가 웹폰트와 현저히 다른 디자인이다보니 폰트가 변경될 시 화면 전환이 크게 일어나는 이슈가 있었다.

2. 시멘틱 마크업
input과 label을 연결시키고 alt 값 표시하지 않은 이미지 태그를 찾아 수정하였다.

3. 이미지 종횡비
스타일을 고려하다보니 원래 이미지의 비율을 css로 명시적으로 조작하여 깨트린 경우가 있는데, 이러한 경우 새로운 이미지를 준비하거나 스타일을 변경해주어야 하기 때문에 해결을 보류하였다.
 
4. 저대비 텍스트
스타일을 고려하다보니 background color와 font color 사이의 저대비가 일어났다. 웹접근성에서 크게 작용하는 부분이기에 스타일을 포기하고 색상 값을 적절히 수정하였다.



