### PR TITLE
Refactor/12 Portal사용하여 Modal 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="나만의 감성 일기장" />
-    <meta property="og:image" content="thumbnail.png" />
+    <meta property="og:image" content="/public/thumbnail.png" />
     <meta property="og:site_name" content="감성 일기장" />
     <meta property="og:description" content="나만의 작은 감성 일기장" />
     <title>감성 일기장</title>

--- a/src/components/Common/DiaryEditor/index.tsx
+++ b/src/components/Common/DiaryEditor/index.tsx
@@ -14,6 +14,8 @@ import EmotionItem from "../EmotionItem";
 import { getStringDate } from "@utils/date";
 import { emotionList } from "@utils/emotion";
 import { DiaryItemType } from "../../../types/diary/diary.type";
+import { PortalModal } from "../Modal";
+import useModal from "@hooks/useModal";
 
 type PropsType = {
   isEdit?: boolean;
@@ -22,6 +24,9 @@ type PropsType = {
 
 const DiaryEditor = ({ isEdit, originData }: PropsType) => {
   const navigate = useNavigate();
+  const { isShowing, toggle } = useModal();
+  const [message, setMessage] = useState("");
+  const [type, setType] = useState("");
   const [emotion, setEmotion] = useState(3);
   const [content, setContent] = useState("");
   const contentRef = useRef<HTMLTextAreaElement>(null);
@@ -38,26 +43,33 @@ const DiaryEditor = ({ isEdit, originData }: PropsType) => {
       contentRef.current?.focus();
       return;
     }
-    if (
-      window.confirm(
-        isEdit ? "일기를 수정하시겠습니까?" : "새로운 일기를 작성하시겠습니까?"
-      )
-    ) {
-      if (originData) {
-        onEdit(originData.id, date, content, emotion);
-      } else {
-        onCreate(date, content, emotion);
-      }
+    isEdit
+      ? setMessage("일기를 수정하시겠습니까?")
+      : setMessage("새로운 일기를 작성하시겠습니까");
+    setType("edit");
+    toggle();
+  };
+
+  const handleEdit = () => {
+    if (originData) {
+      onEdit(originData.id, date, content, emotion);
+    } else {
+      onCreate(date, content, emotion);
     }
+
     navigate("/", { replace: true });
   };
 
+  const handleRemoveModal = () => {
+    setMessage("정말 삭제하시겠습니까?");
+    setType("remove");
+    toggle();
+  };
+
   const handleRemove = () => {
-    if (window.confirm("정말 삭제하시겠습니까?")) {
-      if (originData) {
-        onRemove(originData.id);
-        navigate("/", { replace: true });
-      }
+    if (originData) {
+      onRemove(originData.id);
+      navigate("/", { replace: true });
     }
   };
 
@@ -82,7 +94,11 @@ const DiaryEditor = ({ isEdit, originData }: PropsType) => {
         }
         rightChild={
           isEdit && (
-            <Button variant="negative" text="삭제하기" onClick={handleRemove} />
+            <Button
+              variant="negative"
+              text="삭제하기"
+              onClick={handleRemoveModal}
+            />
           )
         }
       />
@@ -140,8 +156,26 @@ const DiaryEditor = ({ isEdit, originData }: PropsType) => {
           </S.DiaryEditorButtonContainer>
         </S.DiaryEditorTextContainer>
       </S.DiaryEditorSection>
+      <PortalModal
+        isOpen={isShowing}
+        hide={toggle}
+        message={message}
+        handleClick={type === "edit" ? handleEdit : handleRemove}
+      />
     </S.Layout>
   );
 };
 
 export default DiaryEditor;
+
+/* 
+  
+             <PortalModal
+        type={"delete"}
+        isOpen={isShowing}
+        hide={toggle}
+        message={message}
+        handleClick={handleRemove}
+      />
+
+*/

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from "react";
+import * as S from "./style";
+import ReactDOM from "react-dom";
+import Button from "../Button";
+
+type PropsType = {
+  message: string;
+  isOpen: boolean;
+  hide: () => void;
+  handleClick: () => void;
+};
+
+export const PortalModal = ({
+  isOpen,
+  hide,
+  message,
+  handleClick,
+}: PropsType) => {
+  const modalRoot = document.querySelector("#modal-root") as HTMLElement;
+  const [isConfirm, setIsConfirm] = useState(false);
+
+  useEffect(() => {
+    if (isConfirm) {
+      handleClick();
+      hide();
+    }
+  }, [isConfirm]);
+
+  const confirm = () => {
+    setIsConfirm(true);
+  };
+  const cancle = () => {
+    setIsConfirm(false);
+    hide();
+  };
+
+  const modal = (
+    <S.Layout
+      onClick={(e) => {
+        if (e.target instanceof HTMLDivElement) {
+          e.target.dataset.name === "layout" ? hide() : null;
+        }
+      }}
+      data-name="layout"
+    >
+      <S.ModalContainer>
+        <S.ModalText>{message}</S.ModalText>
+        <S.ModalButtonContainer>
+          <Button text="확인" variant="positive" onClick={confirm} />
+          <Button text="취소" variant="default" onClick={cancle} />
+        </S.ModalButtonContainer>
+      </S.ModalContainer>
+    </S.Layout>
+  );
+
+  const content = isOpen ? modal : null;
+
+  return ReactDOM.createPortal(content, modalRoot);
+};

--- a/src/components/Common/Modal/style.tsx
+++ b/src/components/Common/Modal/style.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+export const ModalContainer = styled.div`
+  width: 500;
+  height: 500;
+  padding: 3rem;
+  background-color: white;
+  border-radius: 1rem;
+  box-shadow: rgba(6, 24, 44, 0.4) 0px 0px 0px 2px,
+    rgba(6, 24, 44, 0.65) 0px 4px 6px -1px,
+    rgba(255, 255, 255, 0.08) 0px 1px 0px inset;
+`;
+export const ModalText = styled.p`
+  font-size: 1.8rem;
+  margin-bottom: 2rem;
+`;
+
+export const ModalButtonContainer = styled.div`
+  display: flex;
+  gap: 2em;
+`;
+
+export const Layout = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+`;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+const useModal = () => {
+  const [isShowing, setIsShowing] = useState(false);
+
+  function toggle() {
+    setIsShowing((prev) => !prev);
+  }
+
+  return {
+    isShowing,
+    toggle,
+  };
+};
+
+export default useModal;

--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -31,5 +31,5 @@ export const useTitle: useTitleType = (page) => {
 
       $title.innerHTML = `감성 일기장`;
     }
-  });
+  }, []);
 };


### PR DESCRIPTION
# 구현

- portal을 사용하여 모달을 부모 컴포넌트 바깥에서 렌더링하게 해주었음.
- 컴포넌트에 대한 모달의 의존도를 낮추고 defaultModal을 통해 다른 modal을 쉽게 구현할 수 있도록 useModal 커스텀 훅을 구현하였음.

# 구현 결과

![image](https://user-images.githubusercontent.com/86228307/218252790-ff6cf7eb-203a-459c-91a1-a9e3872f4206.png)
![image](https://user-images.githubusercontent.com/86228307/218252800-195bb89d-3094-4a97-9a11-8ada4b59e806.png)
